### PR TITLE
Clarification about where to get the MuleSoft tile

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -3,7 +3,7 @@ title: Installing and Configuring Anypoint Platform Service Brokers for PCF
 owner: MuleSoft
 ---
 
-This topic describes how a PCF operator installs and configures [Anypoint Platform Service Brokers for PCF](http://docs.pivotal.io/mulesoft/).
+This topic describes how a Pivotal Cloud Foundry (PCF) operator installs and configures [Anypoint Platform Service Brokers for PCF](http://docs.pivotal.io/mulesoft/).
 
 ##<a id='install'></a> Install
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -3,11 +3,11 @@ title: Installing and Configuring Anypoint Platform Service Brokers for PCF
 owner: MuleSoft
 ---
 
-This topic describes how a PCF operator installs and configures Anypoint Platform Service Brokers for Pivotal Cloud Foundry (PCF).
+This topic describes how a PCF operator installs and configures [Anypoint Platform Service Brokers for PCF](http://docs.pivotal.io/mulesoft/).
 
 ##<a id='install'></a> Install
 
-1. Download the product file from [Pivotal Network](https://network.pivotal.io) or [MuleSoft's customer portal](https://www.mulesoft.com/support-login).
+1. Download the product file from [MuleSoft's customer portal](https://www.mulesoft.com/support-login) or get in touch with your MuleSoft account representative.
 
 1. Navigate to the Ops Manager Installation Dashboard and click **Import a Product** to upload the product file.
 


### PR DESCRIPTION
The MuleSoft tile is currently not available on the Pivotal network site, as it's still in beta

I also added a clearer link to the main section at the top